### PR TITLE
metainfo: Fix screenshot URL

### DIFF
--- a/data/io.github.ellie_commons.jorts.metainfo.xml.in
+++ b/data/io.github.ellie_commons.jorts.metainfo.xml.in
@@ -52,15 +52,15 @@
     <screenshots>
         <screenshot type="default">
             <caption>A sticky note with the "Blueberry" theme</caption>
-            <image>https://raw.githubusercontent.com/ellie_commons/jorts/master/data/shot.png</image>
+            <image>https://raw.githubusercontent.com/ellie-commons/Jorts/main/data/shot.png</image>
         </screenshot>
         <screenshot type="default">
             <caption>You can change individual colour and text size!</caption>
-            <image>https://raw.githubusercontent.com/ellie_commons/jorts/master/data/shot2.png</image>
+            <image>https://raw.githubusercontent.com/ellie-commons/Jorts/main/data/shot2.png</image>
         </screenshot>
         <screenshot type="default">
             <caption>You can unzoom so hard you could do ascii art</caption>
-            <image>https://raw.githubusercontent.com/ellie_commons/jorts/master/data/shot3.png</image>
+            <image>https://raw.githubusercontent.com/ellie-commons/Jorts/main/data/shot3.png</image>
         </screenshot>
     </screenshots>
     <content_rating type="oars-1.1"/>


### PR DESCRIPTION
This fixes the screenshots are not shown in AppCenter.

### After
![Screenshot From 2025-03-02 19-39-38](https://github.com/user-attachments/assets/0f19e6f4-390a-454d-90d7-214ce3efae0d)

Tested by building this branch with flatpak-builder and running `io.elementary.appcenter --load-local builddir/export/share/metainfo/io.github.ellie_commons.jorts.metainfo.xml`. Note that this option works as expected only with AppCenter 8.1.0 or later which is only available on Early Access at the moment.

### Before
![image](https://github.com/user-attachments/assets/7b37da0c-5647-4f00-a8d5-2e320cbefe3f)
