### PR TITLE
metainfo: Fix appstreamcli validate warnings

### DIFF
--- a/data/jorts.metainfo.xml.in
+++ b/data/jorts.metainfo.xml.in
@@ -26,10 +26,10 @@
         <name>Stella - Teamcons</name>
     </developer>
     <project_group>ellie-commons</project_group>
-    <url type="homepage">https://github.com/ellie_commons/jorts</url>
-    <url type="bugtracker">https://github.com/ellie_commons/jorts/issues</url>
-    <url type="help">https://github.com/ellie_commons/jorts/issues</url>
-    <url type="translate">https://github.com/ellie_commons/jorts/blob/main/po/README.md</url>
+    <url type="homepage">https://github.com/ellie-commons/jorts</url>
+    <url type="bugtracker">https://github.com/ellie-commons/jorts/issues</url>
+    <url type="help">https://github.com/ellie-commons/jorts/issues</url>
+    <url type="translate">https://github.com/ellie-commons/jorts/blob/main/po/README.md</url>
     <url type="donation">https://ko-fi.com/teamcons</url>
 
     <suggests>
@@ -64,7 +64,7 @@
         </screenshot>
     </screenshots>
     <content_rating type="oars-1.1"/>
-    <translation type="gettext" source_locale="en_GB"></translation>
+    <translation type="gettext" source_locale="en_GB">io.github.ellie_commons.jorts</translation>
     <recommends>
       <control>keyboard</control>
       <control>pointing</control>


### PR DESCRIPTION
This fixes some warnings from `appstreamcli validate` command which I noticed while reviewing your app. This is just a warning and not a critical error, so you don't need to publish another release soon after merging this.

## Before

```
[ryo@b760m ~/work/tmp/Jorts (main $=)]$ appstreamcli validate data/jorts.metainfo.xml.in
I: io.github.ellie_commons.jorts:10: description-first-para-too-short
     Colourful little sticky notes for all of your thoughts :)
W: io.github.ellie_commons.jorts:29: url-not-reachable
     https://github.com/ellie_commons/jorts - URL was not found on the server.
W: io.github.ellie_commons.jorts:30: url-not-reachable
     https://github.com/ellie_commons/jorts/issues - URL was not found on the server.
W: io.github.ellie_commons.jorts:31: url-not-reachable
     https://github.com/ellie_commons/jorts/issues - URL was not found on the server.
W: io.github.ellie_commons.jorts:32: url-not-reachable
     https://github.com/ellie_commons/jorts/blob/main/po/README.md - URL was not found on the
     server.
W: io.github.ellie_commons.jorts:67: tag-empty translation

✘ Validation failed: warnings: 5, infos: 1
[ryo@b760m ~/work/tmp/Jorts (main $=)]$
```

## After

```
[ryo@b760m ~/work/tmp/Jorts (ryonakano/fix-metainfo-warnings)]$ appstreamcli validate data/jorts.metainfo.xml.in
I: io.github.ellie_commons.jorts:10: description-first-para-too-short
     Colourful little sticky notes for all of your thoughts :)

✔ Validation was successful: infos: 1
[ryo@b760m ~/work/tmp/Jorts (ryonakano/fix-metainfo-warnings)]$
```