### PR TITLE
Use int instead of int64 to represent zoom level

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,7 +31,7 @@ namespace jorts {
 
         // Changed whenever a note changes zoom
         // So we can adjust new notes to have whatever user feel is comfortable
-	    public int64 latest_zoom;
+	    public int latest_zoom;
 
 
         /*************************************************/

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -60,7 +60,7 @@ namespace jorts {
         public string title_name;
         public string theme;
         public string content;
-        public int64 zoom;
+        public int zoom;
 
         public SimpleActionGroup actions { get; construct; }
 
@@ -430,7 +430,7 @@ namespace jorts {
         }
 
         // Switch zoom classes, then reflect in the UI and tell the application
-        public void set_zoom(int64 zoom) {
+        public void set_zoom(int zoom) {
             // Switches the classes that control font size
             this.remove_css_class (jorts.Utils.zoom_to_class( this.zoom));
             this.zoom = zoom;

--- a/src/Objects/noteData.vala
+++ b/src/Objects/noteData.vala
@@ -25,10 +25,10 @@ namespace jorts {
         public string title;
         public string theme;
         public string content;
-        public int64 zoom;
+        public int zoom;
 
 
-        public noteData(string title, string theme, string content, int64 zoom )
+        public noteData(string title, string theme, string content, int zoom )
         {
             this.title = title;
             this.theme = theme;

--- a/src/Services/Jason.vala
+++ b/src/Services/Jason.vala
@@ -37,8 +37,11 @@ namespace jorts.Jason {
         string theme    = node.get_string_member_with_default("theme",jorts.Utils.random_theme(null));
         string content  = node.get_string_member_with_default("content","");
         int64 zoom      = node.get_int_member_with_default("zoom",jorts.Constants.DEFAULT_ZOOM);
+        if (zoom < jorts.Constants.ZOOM_MIN || zoom > jorts.Constants.ZOOM_MAX) {
+            zoom = jorts.Constants.DEFAULT_ZOOM;
+        }
 
-        jorts.noteData loaded_note = new jorts.noteData(title, theme, content, zoom);
+        jorts.noteData loaded_note = new jorts.noteData(title, theme, content, (int) zoom);
         return loaded_note;
     }
 

--- a/src/Services/Utils.vala
+++ b/src/Services/Utils.vala
@@ -31,7 +31,7 @@ namespace jorts.Utils {
 
     /*************************************************/
     // We cannot use numbers in CSS, so we have to translate a number into a string
-    public string zoom_to_class(int64 zoom) {
+    public string zoom_to_class(int zoom) {
         switch (zoom) {
             case 20: return "antsized";
             case 40: return "muchsmaller";

--- a/src/Services/Zoom.vala
+++ b/src/Services/Zoom.vala
@@ -55,7 +55,7 @@ namespace jorts.Zoom {
 
 
         // Switch zoom classes, then reflect in the UI and tell the application
-        public void set_zoom(jorts.MainWindow note, int64 zoom) {
+        public void set_zoom(jorts.MainWindow note, int zoom) {
             // Switches the classes that control font size
             note.remove_css_class (jorts.Utils.zoom_to_class( note.zoom));
             note.zoom = zoom;

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -149,13 +149,11 @@ public class jorts.SettingsPopover : Gtk.Popover {
 
     // Called by the Mainwindow when adjusting to new zoomlevel
     // Mainwindow reacts to a signal by the popover
-    public void set_zoomlevel (int64 zoom) {
+    public void set_zoomlevel (int zoom) {
 
-        //TRANSLATORS: ZOOM is replaced by a number. Ex: 100, to display 100%
-        //It must stay as "ZOOM" in the translation so the app can replace it with the current zoom level.
-        //Just consider the "%"
-        var label = _("ZOOM%");
-        label = label.replace ("ZOOM", zoom.to_string ());
+        //TRANSLATORS: %d is replaced by a number. Ex: 100, to display 100%
+        //It must stay as "%d" in the translation so the app can replace it with the current zoom level.
+        var label = _("%d%%").printf (zoom);
         this.zoom_default_button.set_label (label);  
     }
 


### PR DESCRIPTION
Jorts supports zoom levels from 40% up to 240%, which is int (2^32) is enough instead of int64 (2^64).

This allows us to use the common printf format specifier `%d` to replace it with actual zoom level. Plus, it saves memory consumption a little, alghough we don't need to take care of it because Jort is a desktop application, not an embedded application.
