### PR TITLE
Themes: fix editablelabel shift

### DIFF
--- a/data/Themes.css
+++ b/data/Themes.css
@@ -184,15 +184,16 @@ window.themed entry {
 
 window.themed editablelabel {
     color: var(--accent_color_900);
+    border: 1px solid transparent;
 }
 
 window.themed editablelabel:hover,
 window.themed editablelabel:focus {
-    border: 1px solid alpha(var(--accent_color),0.88);
+    border-color: alpha(var(--accent_color),0.88);
 }
 
 window.themed editablelabel.editing {
-    border: 1px solid var(--accent_color_700);
+    border-color: var(--accent_color_700);
 }
 
 window.themed:backdrop editablelabel {


### PR DESCRIPTION
There's a tiny layout shift when hovering over the editablelabel title, due to the border:


https://github.com/user-attachments/assets/04d9cfd7-5c45-412c-ae49-4d5c98d4a919

This PR makes the default state use a 1px transparent border:


https://github.com/user-attachments/assets/7ce05acf-0119-47ff-902d-5efda457cbac

The alternative is to use `outline` instead of `border`, however, you can't do `border-bottom-color` which `window.themed editablelabel.editing` does.